### PR TITLE
Fix retrieval of job results

### DIFF
--- a/Program/get_KEGGid.m
+++ b/Program/get_KEGGid.m
@@ -61,7 +61,7 @@ for i=1:numel(startIdx)
     end
             
     % get job results
-    curl_cmd_jobresult = ['curl -k --silent https://rest.uniprot.org/idmapping/results/' ...
+    curl_cmd_jobresult = ['curl -k --silent https://rest.uniprot.org/idmapping/stream/' ...
         job_id];
     [status, job_result_json] = system(curl_cmd_jobresult);
     if status == 0


### PR DESCRIPTION
* when /idmapping/results was used, only the first 50 results are returned
* replaced results with stream and all results are returned